### PR TITLE
Adapt to backend stop architecture changes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ declare global {
     downloadProgressed: ((progress: number, eta: string) => void) | undefined;
     hotkeyReceived: ((hotkey: string, hotkeyData: number[]) => void) | undefined;
     finishSound: ((playingSound: PlayingSound) => void) | undefined;
+    onStopHotkey: (() => void) | undefined;
     onSoundPlayed: ((playingSound: PlayingSound) => void) | undefined;
     updateSound: ((playingSound: PlayingSound) => void) | undefined;
     onError: ((error: string) => void) | undefined;
@@ -31,7 +32,7 @@ declare global {
     setHotkey: (id: number, hotkeys: number[]) => Promise<void>;
     isSwitchOnConnectLoaded: () => Promise<boolean | null>;
     unloadSwitchOnConnect: () => Promise<void>;
-    stopSounds: () => Promise<boolean | null>;
+    stopSounds: () => Promise<void>;
     startPassthrough: (name: string) => Promise<boolean | null>;
     stopPassthrough: () => Promise<void>;
     playSound: (id: number) => Promise<PlayingSound | null>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ declare global {
     // frontend callback functions
     downloadProgressed: ((progress: number, eta: string) => void) | undefined;
     hotkeyReceived: ((hotkey: string, hotkeyData: number[]) => void) | undefined;
-    finishSound: ((playingSound: PlayingSound, forced: boolean) => void) | undefined;
+    finishSound: ((playingSound: PlayingSound) => void) | undefined;
     onSoundPlayed: ((playingSound: PlayingSound) => void) | undefined;
     updateSound: ((playingSound: PlayingSound) => void) | undefined;
     onError: ((error: string) => void) | undefined;
@@ -31,7 +31,7 @@ declare global {
     setHotkey: (id: number, hotkeys: number[]) => Promise<void>;
     isSwitchOnConnectLoaded: () => Promise<boolean | null>;
     unloadSwitchOnConnect: () => Promise<void>;
-    stopSounds: () => Promise<void>;
+    stopSounds: () => Promise<boolean | null>;
     startPassthrough: (name: string) => Promise<boolean | null>;
     stopPassthrough: () => Promise<void>;
     playSound: (id: number) => Promise<PlayingSound | null>;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -447,11 +447,8 @@ export default new Vuex.Store({
     /**
      * Stop all sounds via the backend
      */
-    async stopSounds({ commit }) {
-      const success = await window.stopSounds();
-      if (success) {
-        commit('clearCurrentlyPlaying');
-      }
+    async stopSounds() {
+      await window.stopSounds();
     },
 
     /**

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -209,6 +209,8 @@ export default new Vuex.Store({
       });
       if (realSound) {
         state.currentPlaying.splice(state.currentPlaying.indexOf(realSound), 1);
+      } else {
+        console.warn('removeFromCurrentlyPlaying called but playing not found', JSON.stringify(playing));
       }
     },
     deleteSound: (state, sound: Sound) => {
@@ -446,8 +448,10 @@ export default new Vuex.Store({
      * Stop all sounds via the backend
      */
     async stopSounds({ commit }) {
-      await window.stopSounds();
-      commit('clearCurrentlyPlaying');
+      const success = await window.stopSounds();
+      if (success) {
+        commit('clearCurrentlyPlaying');
+      }
     },
 
     /**

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -447,8 +447,9 @@ export default new Vuex.Store({
     /**
      * Stop all sounds via the backend
      */
-    async stopSounds() {
+    async stopSounds({ commit }) {
       await window.stopSounds();
+      commit('clearCurrentlyPlaying');
     },
 
     /**

--- a/src/utils/backend.ts
+++ b/src/utils/backend.ts
@@ -36,10 +36,10 @@ export async function initialize(): Promise<void> {
       console.warn('Could not find sound for playingSound with id', playingSound.id);
     }
   };
-  window.finishSound = (playingSound: PlayingSound, forced: boolean) => {
+  window.finishSound = (playingSound: PlayingSound) => {
     $store.commit('removeFromCurrentlyPlaying', playingSound);
     // if the playlist mode is enabled, the playback was not force stopped (e.g. via hotkey) and there are no sounds playing continue with the next sound
-    if ($store.getters.playlistMode && !forced && $store.getters.currentPlayingSounds.length === 0) {
+    if ($store.getters.playlistMode && $store.getters.currentPlayingSounds.length === 0) {
       const soundId = playingSound.sound.id;
 
       const tabs: Tab[] = $store.getters.tabs;

--- a/src/utils/backend.ts
+++ b/src/utils/backend.ts
@@ -36,6 +36,8 @@ export async function initialize(): Promise<void> {
       console.warn('Could not find sound for playingSound with id', playingSound.id);
     }
   };
+
+  // when a sound finishes playing
   window.finishSound = (playingSound: PlayingSound) => {
     $store.commit('removeFromCurrentlyPlaying', playingSound);
     // if the playlist mode is enabled, the playback was not force stopped (e.g. via hotkey) and there are no sounds playing continue with the next sound
@@ -65,6 +67,13 @@ export async function initialize(): Promise<void> {
       }
     }
   };
+
+  // when the stop hotkey was pressed
+  window.onStopHotkey = () => {
+    $store.commit('clearCurrentlyPlaying');
+  };
+
+  // when a sound started playing via hotkey
   window.onSoundPlayed = (playingSound: PlayingSound) => {
     if (playingSound) {
       $store.commit('addToCurrentlyPlaying', playingSound);


### PR DESCRIPTION
Can be merged once the backend architecture has been adjusted accordingly:

`stopSounds` - return boolean success, don't call `finishSound`
`stopSound` - don't call `finishSound`
`finishSound` call - remove `force` parameter as it's now obsolete