### PR TITLE
Update translation files

### DIFF
--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -21,7 +21,6 @@
     "refresh": "Ανανέωση"
   },
   "settings": {
-    "darkTheme": "Σκούρο θέμα",
     "gridView": "Προβολή σε πλέγμα",
     "stopHotkey": "Συντόμευση διακοπής",
     "title": "Ρυθμίσεις"
@@ -33,7 +32,6 @@
     },
     "title": "Βοήθεια",
     "play": {
-      "doubleClick": "Διπλό-κλικ",
       "play": "αναπαραγωγή",
       "text": "{doubleClick} για {play}"
     },

--- a/src/locales/nb_NO.json
+++ b/src/locales/nb_NO.json
@@ -36,7 +36,6 @@
       "search": "søke",
       "text": "Trykk {ctrl} + {f} for å {search}"
     },
-    "ctrl": "Ctrl",
     "title": "Hjelp",
     "play": {
       "text": "{doubleClick} for å {play}",
@@ -65,13 +64,10 @@
     "title": "Bytt ved tilkobling-modul oppdaget."
   },
   "settings": {
-    "darkTheme": "Mørk drakt",
     "muteDuringPlayback": "Demp mikrofon under avspilling",
     "useAsDefaultDevice": "Bruk som forvalgt enhet",
-    "gridView": "Rutenettvisning",
     "allowOverlapping": "Tillat lydoverlapping",
     "title": "Innstillinger",
-    "launchpadMode": "Launchpad-modus",
     "stopHotkey": "Stopp-snarvei",
     "tabHotkeysOnly": "Snarveier kun for nåværende fane"
   },
@@ -93,7 +89,6 @@
   "input": {
     "ctrl": "Ctrl",
     "arrowKeys": "Piltaster",
-    "doubleClick": "Dobbeltklikk",
     "enter": "Enter",
     "shift": "Shift"
   },

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -17,7 +17,6 @@
     }
   },
   "settings": {
-    "darkTheme": "Темная тема",
     "title": "Настройки"
   },
   "actions": {


### PR DESCRIPTION
Updated by "Cleanup translation files" hook in Weblate.

Translation: Soundux/Frontend
Translate-URL: https://hosted.weblate.org/projects/soundux/frontend/